### PR TITLE
fix: verify SystemKeys directory exists before copying transport key

### DIFF
--- a/Device.ps1
+++ b/Device.ps1
@@ -258,7 +258,11 @@ function Join-LocalDeviceToAzureAD
         Write-Verbose "TransportKey file name: $($transportKey.UniqueName)"
 
         # Copy the private key to SystemKeys folder & delete from the current location
-        Copy-Item -Path "$env:ALLUSERSPROFILE\Microsoft\Crypto\Keys\$($transportKey.UniqueName)" -Destination "$env:ALLUSERSPROFILE\Microsoft\Crypto\SystemKeys" -Force
+        $systemKeysDir = "$env:ALLUSERSPROFILE\Microsoft\Crypto\SystemKeys"
+        if (-not (Test-Path $systemKeysDir)) {
+            New-Item -ItemType Directory -Path $systemKeysDir -Force | Out-Null
+        }
+        Copy-Item -Path "$env:ALLUSERSPROFILE\Microsoft\Crypto\Keys\$($transportKey.UniqueName)" -Destination "$systemKeysDir\" -Force
         Write-Verbose "Transport key stored to $env:ALLUSERSPROFILE\Microsoft\Crypto\SystemKeys\$($transportKey.UniqueName)"
         $transportKey.Delete()
 


### PR DESCRIPTION
# Summary

- This PR fixes an issue with KeySignTest failures when joining a machine to Azure AD.

## Type of Change

- [x] [Bug fix](?expand=1&template=bugfix-template.md)

## Description

Previously, copying the transport key would convert the `SystemKeys` folder into a file, preventing proper key storage and retrieval. This change ensures the folder structure remains intact while copying the key.

Fixes: https://github.com/Gerenios/AADInternals/issues/82