### PR TITLE
Fix KeyName variable to make sure Find-Privatekey exports the requested key

### DIFF
--- a/CommonUtils_endpoints.ps1
+++ b/CommonUtils_endpoints.ps1
@@ -1172,7 +1172,7 @@ function Find-PrivateKey
                             default { throw "Unsupported key blob type" }
                         }
                                                         
-                        if($key.name -eq $transPortKeyName)
+                        if($key.name -eq $KeyName)
                         {
                             Write-Verbose "Key for name $KeyName found!"
                             break


### PR DESCRIPTION
Currently it tries to match the key name with an undefined variable so in practice it will always extract the last key encountered, which may not be the key we actually want.